### PR TITLE
Python -m and misc text tweaks

### DIFF
--- a/python/lesson01/README.md
+++ b/python/lesson01/README.md
@@ -12,7 +12,7 @@ Learn how to:
 
 ### A simple Hello-World program
 
-Let's create a simple Python program `lesson01/exercise/hello.py` that takes an argument and prints "Hello, {arg}!". 
+Let's create a simple Python program `lesson01/exercise/hello.py` that takes an argument and prints "Hello, {arg}!".
 
 ```
 mkdir lesson01/exercise
@@ -33,7 +33,7 @@ hello_to = sys.argv[1]
 say_hello(hello_to)
 ```
 
-Run it: 
+Run it:
 ```
 $ python -m lesson01.exercise.hello Bryan
 Hello, Bryan!
@@ -75,7 +75,7 @@ def say_hello(hello_to):
 ```
 
 If we run this program, we will see no difference, and no traces in the tracing UI.
-That's because the variable `opentracing.tracer` points to a no-op tracer by default.
+That's because the variable `opentracing.tracer` points to is a no-op tracer by default.
 
 ### Initialize a real tracer
 
@@ -105,7 +105,7 @@ def init_tracer(service):
     return config.initialize_tracer()
 ```
 
-To use this instance, let's change the main function:
+To use this instance, let's replace `opentracing.tracer` with `init_tracer(...)`:
 
 ```python
 tracer = init_tracer('hello-world')
@@ -119,6 +119,10 @@ so it has an internal buffer of spans that is flushed by a background thread. Si
 it may not have time to flush the spans to Jaeger backend. Let's add the following to the end of `hello.py`:
 
 ```
+import time
+
+# ...
+
 # yield to IOLoop to flush the spans
 time.sleep(2)
 tracer.close()
@@ -152,9 +156,9 @@ more general operation names is to allow the tracing systems to do aggregations.
 has an option of emitting metrics for all the traffic going through the application. Having a unique
 operation name for each span would make the metrics useless.
 
-The recommended solution is to annotate spans with tags or logs. A span _tag_ is a key-value pair that provides
-certain metadata about the span. A span _log_ is pretty much the same as a regular log statement, it contains
-a timestamp and some data.
+The recommended solution is to annotate spans with tags or logs. A _tag_ is a key-value pair that provides
+certain metadata about the span. A _log_ is similar to a regular log statement, it contains
+a timestamp and some data, but it is associated with span from which it was logged.
 
 When should we use tags vs. logs?  The tags are meant to describe attributes of the span that apply
 to the whole duration of the span. For example, if a span represents an HTTP request, then the URL of the
@@ -177,7 +181,7 @@ with tracer.start_span('say-hello') as span:
 #### Using Logs
 
 Our hello program is so simple that it's difficult to find a relevant example of a log, but let's try.
-Right now we're formatting the `helloStr` and then printing it. Both of these operations take certain
+Right now we're formatting the `hello_str` and then printing it. Both of these operations take certain
 time, so we can log their completion:
 
 ```python
@@ -188,7 +192,7 @@ print(hello_str)
 span.log_kv({'event': 'println'})
 ```
 
-The log statements might look a bit strange if you have not previosuly worked with structured logging API.
+The log statements might look a bit strange if you have not previosuly worked with a structured logging API.
 Rather than formatting a log message into a single string that is easy for humans to read, structured
 logging APIs encourage you to separate bits and pieces of that message into key-value pairs that can be
 automatically processed by log aggregation systems. The idea comes from the realization that today most
@@ -206,8 +210,8 @@ you will be able to see the tags and logs.
 
 ## Conclusion
 
-The complete program can be found in the [solution](./solution) package. We moved the `initJaeger`
-helper function into its own package so that we can reuse it in the other lessons as `tracing.Init`.
+The complete program can be found in the [solution](./solution) package. We moved the `init_tracer`
+helper function into its own package so that we can reuse it in the other lessons as `from lib.tracing import init_tracer`.
 
 Next lesson: [Context and Tracing Functions](../lesson02).
 

--- a/python/lesson02/README.md
+++ b/python/lesson02/README.md
@@ -95,7 +95,8 @@ The label, or `ReferenceType`, describes the nature of the relationship. `ChildO
 means that the `root_span` has a logical dependency on the child `span` before `root_span` can
 complete its operation. Another standard reference type in OpenTracing is `FollowsFrom`, which
 means the `root_span` is the ancestor in the DAG, but it does not depend on the completion of the
-child span, for example if the child represents a best-effort, fire-and-forget cache write.
+child span, for example if the child represents a best-effort, fire-and-forget cache write or
+down-stream processing in an event-driven architecture.
 
 If we modify the `print_hello` function accordingly and run the app, we'll see that all reported
 spans now belong to the same trace:
@@ -173,6 +174,6 @@ tracing functions automatically - they have a stable way of finding the current 
 
 ## Conclusion
 
-The complete program can be found in the [solution](./solution) package. 
+The complete program can be found in the [solution](./solution) package.
 
 Next lesson: [Tracing RPC Requests](../lesson03).

--- a/python/lesson03/README.md
+++ b/python/lesson03/README.md
@@ -28,7 +28,7 @@ To test it out, run the formatter and publisher services in separate terminals
 
 ```
 # terminal 2
-$ python lesson03/exercise/formatter.py
+$ python -m lesson03.exercise.formatter
  * Running on http://127.0.0.1:8081/ (Press CTRL+C to quit)
 
 # terminal 3
@@ -123,7 +123,7 @@ def http_get(port, path, param, value):
     return r.text
 ```
 
-Notice that we also add a couple additional tags to the span with some metadata about the HTTP request, 
+Notice that we also add a couple additional tags to the span with some metadata about the HTTP request,
 and we mark the span with a `span.kind=client` tag, as recommended by the OpenTracing
 [Semantic Conventions][semantic-conventions]. There are other tags we could add.
 
@@ -134,7 +134,7 @@ from opentracing.ext import tags
 from opentracing.propagation import Format
 ```
 
-You cam rerun `hello.py` program now, but we won't see any difference.
+You can rerun `hello.py` program now, but we won't see any difference.
 
 ### Instrumenting the Servers
 
@@ -154,13 +154,13 @@ Add a member variable and a constructor to the Formatter:
 
 ```python
 app = Flask(__name__)
-tracer = init_tracer('formatter') 
+tracer = init_tracer('formatter')
 ```
 
 #### Extract the span context from the incoming request using `tracer.extract`
 
 The logic here is similar to the client side instrumentation, except that we are using `tracer.extract`
-and tagging the span as `span.kind=server`. 
+and tagging the span as `span.kind=server`.
 
 ```python
 @app.route("/format")
@@ -225,7 +225,7 @@ If we open this trace in the UI, we should see all five spans.
 
 ## Conclusion
 
-The complete program can be found in the [solution](./solution) package. 
+The complete program can be found in the [solution](./solution) package.
 
 Next lesson: [Baggage](../lesson04).
 
@@ -236,4 +236,4 @@ need to do that because that instrumentation itself is open source. For an extra
 modules from https://github.com/uber-common/opentracing-python-instrumentation and
 https://github.com/opentracing-contrib/python-flask to avoid instrumenting your code manually.
 
-[semantic-conventions]: https://github.com/opentracing/specification/blob/master/semantic_conventions.md
+[semantic-conventions]: https://github.com/opentracing/specification/blob/master/semantic_conventions.md#standard-span-tags-and-log-fields

--- a/python/lesson03/exercise/publisher.py
+++ b/python/lesson03/exercise/publisher.py
@@ -2,12 +2,12 @@ from flask import Flask
 from flask import request
 
 app = Flask(__name__)
- 
+
 @app.route("/publish")
-def format():
+def publish():
     hello_str = request.args.get('helloStr')
     print(hello_str)
     return 'published'
- 
+
 if __name__ == "__main__":
     app.run(port=8082)

--- a/python/lesson03/solution/hello.py
+++ b/python/lesson03/solution/hello.py
@@ -15,14 +15,14 @@ def say_hello(hello_to):
             print_hello(hello_str)
 
 def format_string(hello_to):
-    with tracer.start_span('format', child_of=get_current_span()) as span:
+    with tracer.start_span('formatString', child_of=get_current_span()) as span:
         with span_in_context(span):
             hello_str = http_get(8081, 'format', 'helloTo', hello_to)
             span.log_kv({'event': 'string-format', 'value': hello_str})
             return hello_str
 
 def print_hello(hello_str):
-    with tracer.start_span('println', child_of=get_current_span()) as span:
+    with tracer.start_span('printHello', child_of=get_current_span()) as span:
         with span_in_context(span):
             http_get(8082, 'publish', 'helloStr', hello_str)
             span.log_kv({'event': 'println'})
@@ -40,7 +40,7 @@ def http_get(port, path, param, value):
     r = requests.get(url, params={param: value}, headers=headers)
     assert r.status_code == 200
     return r.text
-        
+
 
 # main
 assert len(sys.argv) == 2

--- a/python/lesson03/solution/publisher.py
+++ b/python/lesson03/solution/publisher.py
@@ -5,16 +5,16 @@ from opentracing.ext import tags
 from opentracing.propagation import Format
 
 app = Flask(__name__)
-tracer = init_tracer('publisher') 
- 
+tracer = init_tracer('publisher')
+
 @app.route("/publish")
-def format():
+def publish():
     span_ctx = tracer.extract(Format.HTTP_HEADERS, request.headers)
     span_tags = {tags.SPAN_KIND: tags.SPAN_KIND_RPC_SERVER}
     with tracer.start_span('publish', child_of=span_ctx, tags=span_tags):
         hello_str = request.args.get('helloStr')
         print(hello_str)
         return 'published'
- 
+
 if __name__ == "__main__":
     app.run(port=8082)

--- a/python/lesson04/README.md
+++ b/python/lesson04/README.md
@@ -125,11 +125,11 @@ Some of the possible applications of baggage include:
 
 ### Now, a Warning... NOW a Warning?
 
-Of course, while baggage is extermely powerful mechanism, it is also dangerous. If we store a 1Mb value/string
+Of course, while baggage is an extermely powerful mechanism, it is also dangerous. If we store a 1Mb value/string
 in baggage, every request in the call graph below that point will have to carry that 1Mb of data. So baggage
 must be used with caution. In fact, Jaeger client libraries implement centrally controlled baggage restrictions,
 so that only blessed services can put blessed keys in the baggage, with possible restrictions on the value length.
 
 ## Conclusion
 
-The complete program can be found in the [solution](./solution) package. 
+The complete program can be found in the [solution](./solution) package.


### PR DESCRIPTION
Great tutorial. 

Mostly minor suggestions for text changes. 

The only significant change is the invocation of formatter for lesson 3:

```
-$ python lesson03/exercise/formatter.py
+$ python -m lesson03.exercise.formatter
```

I ran into an error until making that adjustment.