### PR TITLE
Clarifying the linked libraries

### DIFF
--- a/python/extracredit/README.md
+++ b/python/extracredit/README.md
@@ -1,11 +1,9 @@
 # Extra Credit - Using Existing Open Source Instrumentation
 
 Adding manual instrumentation to `flask` and `requests` like we did in [Lesson 3](../lesson03)
-is tedious. Fortunately, we don't need to do that because that instrumentation itself already exists
-as open source modules. For an extra credit, try to use these libraries to avoid instrumenting your
+is tedious. Fortunately, we don't need to do that because that instrumentation already exists
+as open source modules. For extra credit, use these libraries to avoid instrumenting your
 code manually:
 
- * https://github.com/uber-common/opentracing-python-instrumentation
- * https://github.com/opentracing-contrib/python-flask
-
-There is another tutorial specifically for the Flask framework: http://blog.scoutapp.com/articles/2018/01/15/tutorial-tracing-python-flask-requests-with-opentracing
+ * [opentracing-python-instrumentation](https://github.com/uber-common/opentracing-python-instrumentation) - instruments requests, SQLAlchemy, redis, and more.
+ * [python-flask](https://github.com/opentracing-contrib/python-flask) - automatically instruments web requests to Flask apps. [This tutorial](http://blog.scoutapp.com/articles/2018/01/15/tutorial-tracing-python-flask-requests-with-opentracing) walks through the setup.


### PR DESCRIPTION
Indicated which contrib module instruments what and associated the Flask tutorial with the `python_flask` module.