### PR TITLE
go-lesson03: Fix unclear client instrumentation in lesson

### DIFF
--- a/go/lesson03/README.md
+++ b/go/lesson03/README.md
@@ -81,7 +81,17 @@ The tracing instrumentation uses `Inject` and `Extract` to pass the span context
 ### Instrumenting the Client
 
 In the `formatString` function we already create a child span. In order to pass its context over the HTTP
-request we need to call `Inject` on the tracer:
+request we need to do the following:
+
+#### Add an import
+
+```go
+import (
+    "github.com/opentracing/opentracing-go/ext"
+)
+```
+
+#### Call `Inject` on the tracer
 
 ```go
 ext.SpanKindRPCClient.Set(span)

--- a/go/lesson03/exercise/client/hello.go
+++ b/go/lesson03/exercise/client/hello.go
@@ -39,10 +39,12 @@ func formatString(ctx context.Context, helloTo string) string {
 
 	v := url.Values{}
 	v.Set("helloTo", helloTo)
-	req, err := http.NewRequest("GET", "http://localhost:8081/format?"+v.Encode(), nil)
+	url := "http://localhost:8081/format?" + v.Encode()
+	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		panic(err.Error())
 	}
+
 	resp, err := xhttp.Do(req)
 	if err != nil {
 		panic(err.Error())
@@ -64,10 +66,12 @@ func printHello(ctx context.Context, helloStr string) {
 
 	v := url.Values{}
 	v.Set("helloStr", helloStr)
-	req, err := http.NewRequest("GET", "http://localhost:8082/publish?"+v.Encode(), nil)
+	url := "http://localhost:8082/publish?" + v.Encode()
+	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		panic(err.Error())
 	}
+
 	if _, err := xhttp.Do(req); err != nil {
 		panic(err.Error())
 	}


### PR DESCRIPTION
This is an attempt to fix issue #18 .  For the exercise code I mirrored the solution code, and for the lesson text I mirrored the server instrumentation portion below it. It might sound a bit strange to repeat the same "need to do the following" phrase twice but that can of course be changed if you prefer something else.

The extra newlines added to the exercise code was added both because it mirrors the solution code and also that it is a subtle hint that it might be a good spot to add the new chunk of code.