### PR TITLE
update doc to run jaegertracing with 6832/udp open for node.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ For this tutorial, we'll start Jaeger via Docker with the default in-memory stor
 docker run \
   --rm \
   -p 6831:6831/udp \
+  -p 6832:6832/udp \
   -p 16686:16686 \
   jaegertracing/all-in-one:1.7 \
   --log-level=debug


### PR DESCRIPTION
It seems to require 6832/udp in order to run node.js examples.
Just updating readme to run jaegertracing container according to https://www.jaegertracing.io/docs/1.7/getting-started/, which opens necessary ports including 6832/udp.