### PR TITLE
[C#] Update Jaeger nuget dependencies for Lesson3 and Lesson4 

### DIFF
--- a/csharp/src/lesson03/solution/Lesson03.Solution.Server/Lesson03.Solution.Server.csproj
+++ b/csharp/src/lesson03/solution/Lesson03.Solution.Server/Lesson03.Solution.Server.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Jaeger" Version="0.0.10" />
+    <PackageReference Include="Jaeger" Version="0.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.8" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.0.4" />
     <PackageReference Include="OpenTracing.Contrib.NetCore" Version="0.4.0" />

--- a/csharp/src/lesson04/solution/Lesson04.Solution.Server/Lesson04.Solution.Server.csproj
+++ b/csharp/src/lesson04/solution/Lesson04.Solution.Server/Lesson04.Solution.Server.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Jaeger" Version="0.0.10" />
+    <PackageReference Include="Jaeger" Version="0.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.8" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.0.4" />
     <PackageReference Include="OpenTracing.Contrib.NetCore" Version="0.4.0" />


### PR DESCRIPTION
Update Jaeger NuGet dependencies for `Lesson3.Server` and` Lesson4.Server` so they don't conflict with `Library` project. I've updated them from `0.0.10` to `0.1.0` both. 
Build errors:
![image](https://user-images.githubusercontent.com/11834902/48984092-f276d180-f0ff-11e8-88e1-d0a9a18fe3af.png)
![image](https://user-images.githubusercontent.com/11834902/48984093-f6a2ef00-f0ff-11e8-8eb0-63b3c167d638.png)

Another way to solve this problem is to remove Jaeger NuGet packages from both projects and use the ones referenced in the `Library` project. However, I don't think it's a good idea because we lose the illustrativeness of these examples. 
