### PR TITLE
Update the locked versions of all dependencies

### DIFF
--- a/go/Makefile
+++ b/go/Makefile
@@ -1,4 +1,4 @@
 .PHONY: install
 install:
 	dep version || go get -u github.com/golang/dep/cmd/dep
-	dep ensure
+	dep ensure -update


### PR DESCRIPTION
This ensures the locked versions of all dependencies get updated (especially important for the jaeger package being used in the tutorial if you're trying to move away from some of the deprecated methods).