### PR TITLE
Fix typo in lesson 3 README.md

### DIFF
--- a/go/lesson03/README.md
+++ b/go/lesson03/README.md
@@ -35,7 +35,7 @@ Execute an HTTP request against the formatter:
 
 ```
 $ curl 'http://localhost:8081/format?helloTo=Bryan'
-Hello, Bryan!%
+Hello, Bryan!
 ```
 
 Execute and HTTP request against the publisher:

--- a/go/lesson03/README.md
+++ b/go/lesson03/README.md
@@ -35,7 +35,7 @@ Execute an HTTP request against the formatter:
 
 ```
 $ curl 'http://localhost:8081/format?helloTo=Bryan'
-Hello, Bryan!
+Hello, Bryan!$
 ```
 
 Execute and HTTP request against the publisher:


### PR DESCRIPTION
Changed trailing `%` to `$` to reflect the shell prompt in the example.