### PR TITLE
fixing typos in java README.

### DIFF
--- a/java/src/main/java/lesson01/README.md
+++ b/java/src/main/java/lesson01/README.md
@@ -197,7 +197,7 @@ System.out.println(helloStr);
 span.log(ImmutableMap.of("event", "println"));
 ```
 
-The log statements might look a bit strange if you have not previosuly worked with a structured logging API.
+The log statements might look a bit strange if you have not previously worked with a structured logging API.
 Rather than formatting a log message into a single string that is easy for humans to read, structured
 logging APIs encourage you to separate bits and pieces of that message into key-value pairs that can be
 automatically processed by log aggregation systems. The idea comes from the realization that today most

--- a/java/src/main/java/lesson03/README.md
+++ b/java/src/main/java/lesson03/README.md
@@ -257,7 +257,7 @@ $ ./run.sh lesson03.exercise.Hello Bryan
 
 Note how all recorded spans show the same trace ID `ed5421da32d2cbe9`. This is a sign
 of correct instrumentation. It is also a very useful debugging approach when something
-is wrong with tracing. A typical error is to miss the context propagation somwehere,
+is wrong with tracing. A typical error is to miss the context propagation somewhere,
 either in-process or inter-process, which results in different trace IDs and broken
 traces.
 

--- a/java/src/main/java/lesson04/README.md
+++ b/java/src/main/java/lesson04/README.md
@@ -111,7 +111,7 @@ Some of the possible applications of baggage include:
 
 ### Now, a Warning... NOW a Warning?
 
-Of course, while baggage is an extermely powerful mechanism, it is also dangerous. If we store a 1Mb value/string
+Of course, while baggage is an extremely powerful mechanism, it is also dangerous. If we store a 1Mb value/string
 in baggage, every request in the call graph below that point will have to carry that 1Mb of data. So baggage
 must be used with caution. In fact, Jaeger client libraries implement centrally controlled baggage restrictions,
 so that only blessed services can put blessed keys in the baggage, with possible restrictions on the value length.


### PR DESCRIPTION
Fixed a few typos while going through the java tutorial. Please accept or let me know if I am missing any additional contributor's step.