### PR TITLE
update jaeger python client version and move it to jaegertracing repo

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,4 +1,4 @@
-jaeger-client>=3.8,<4
+jaeger-client>=4.3,<5
 
 requests
 flask

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,9 +1,4 @@
-opentracing>=2,<3
-
-# We want something like: jaeger-client>=3.8,<4
-# But Scope Manager support not officially released in Jaeger at the time of writing.
-# This is using branch 'feature/opentracing-2.0-support' in @yurishkuro's fork.
--e git+https://github.com/jaegertracing/jaeger-client-python.git@ef62773da0c273070190f736f921367c81c0e603#egg=jaeger-client
+jaeger-client>=3.8,<4
 
 requests
 flask

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -3,7 +3,7 @@ opentracing>=2,<3
 # We want something like: jaeger-client>=3.8,<4
 # But Scope Manager support not officially released in Jaeger at the time of writing.
 # This is using branch 'feature/opentracing-2.0-support' in @yurishkuro's fork.
--e git+https://github.com/yurishkuro/jaeger-client-python.git@d631596415cb549a4e8314cc25d6c53fab710528#egg=jaeger-client
+-e git+https://github.com/jaegertracing/jaeger-client-python.git@ef62773da0c273070190f736f921367c81c0e603#egg=jaeger-client
 
 requests
 flask


### PR DESCRIPTION
This pull request updates jaeger python client repository to jaegertracing and bump its version to 4.3.0.

This will resolve marking spans as erroneous issue when either of the publisher or the formatter are down in exercise03, exercise04.